### PR TITLE
Warnings and minor UX improvements for OTA upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## v0.4.2 = 2023-02-20
+## Unreleased
+
+- Warn when trying to flash unsupported firmware release or mismatching resource version
+- Disable resource flash and download buttons for releases without resources
+
+## v0.4.2 - 2023-02-20
 
 - Improve notifications permission error message
 

--- a/watchmate/src/ui/dashboard.rs
+++ b/watchmate/src/ui/dashboard.rs
@@ -491,6 +491,9 @@ impl Component for Model {
                 self.address = Some(address);
             }
             Input::FirmwareVersion(version) => {
+                self.firmware_panel.emit(
+                    firmware_panel::Input::CurrentFirmwareVersion(version.clone())
+                );
                 self.fw_version = Some(version);
                 self.check_fw_update_available();
             }

--- a/watchmate/src/ui/firmware_panel.rs
+++ b/watchmate/src/ui/firmware_panel.rs
@@ -94,6 +94,7 @@ pub struct Model {
     releases: FirmwareReleasesState,
     tags: Option<gtk::StringList>,
     selected_index: u32,
+    resources_available: bool,
     current_version: String,
     // Firmware download state
     download_task: Option<JoinHandle<()>>,
@@ -191,17 +192,21 @@ impl Component for Model {
                             set_orientation: gtk::Orientation::Vertical,
 
                             gtk::Button {
-                                set_label: "Flash Resources",
-                                connect_clicked => Input::FlashResourcesFromReleaseClicked,
-                            },
-
-                            gtk::Button {
                                 set_label: "Download",
                                 connect_clicked => Input::DownloadFirmware,
                             },
 
                             gtk::Button {
+                                set_label: "Flash Resources",
+                                #[watch]
+                                set_sensitive: model.resources_available,
+                                connect_clicked => Input::FlashResourcesFromReleaseClicked,
+                            },
+
+                            gtk::Button {
                                 set_label: "Download Resources",
+                                #[watch]
+                                set_sensitive: model.resources_available,
                                 connect_clicked => Input::DownloadResources,
                             },
 
@@ -341,6 +346,7 @@ impl Component for Model {
             releases: FirmwareReleasesState::default(),
             tags: None,
             selected_index: 0,
+            resources_available: false,
             current_version: String::new(),
             download_task: None,
             download_content: None,
@@ -371,6 +377,9 @@ impl Component for Model {
             }
             Input::SelectedRelease(index) => {
                 self.selected_index = index;
+                if let Some(release) = self.selected_release_info() {
+                    self.resources_available = release.get_resources_asset().is_some();
+                }
             }
             Input::ReleaseNotes => {
                 if let Some(release) = self.selected_release_info() {


### PR DESCRIPTION
- Warn when trying to flash unsupported firmware release
- Warn when trying to flash mismatching resource version
- Disable resource flash and download buttons for releases without resources