### PR TITLE
Add metadata for mobile devices using Phosh

### DIFF
--- a/assets/io.gitlab.azymohliad.WatchMate.desktop
+++ b/assets/io.gitlab.azymohliad.WatchMate.desktop
@@ -8,3 +8,5 @@ Terminal=false
 Type=Application
 Categories=Utility;GNOME;GTK;
 Keywords=InfiniTime;PineTime;Smartwatch;Companion;Time;
+# Translators: Do NOT translate or transliterate this text (these are enum types)!
+X-Purism-FormFactor=Workstation;Mobile;

--- a/assets/io.gitlab.azymohliad.WatchMate.metainfo.xml
+++ b/assets/io.gitlab.azymohliad.WatchMate.metainfo.xml
@@ -125,6 +125,11 @@
     </release>
   </releases>
 
+  <custom>
+    <value key="Purism::form_factor">workstation</value>
+    <value key="Purism::form_factor">mobile</value>
+  </custom>
+
   <developer_name>Andrii Zymohliad</developer_name>
   <update_contact>azymohliad@proton.me</update_contact>
 </component>


### PR DESCRIPTION
This will enable WatchMate to show up as Mobile friendly on the default app screen in Phosh and in the PureOS app store.