### PR TITLE
Bluetooth stability improvements

### DIFF
--- a/watchmate/src/ui/devices_page.rs
+++ b/watchmate/src/ui/devices_page.rs
@@ -1,5 +1,5 @@
 use crate::ui;
-use std::{str::FromStr, time::Duration};
+use std::str::FromStr;
 use infinitime::{ bluer, bt };
 use std::sync::Arc;
 use futures::{pin_mut, StreamExt};
@@ -297,15 +297,6 @@ impl Component for Model {
             Input::DiscoveryFailed => {
                 log::error!("Device discovery failed");
                 self.discovery_task = None;
-                // Retry. Usually the discovery fails when the bluetooth
-                // adapter is lost, and in that case this retry will be
-                // ignored and will be attempted next time only after
-                // the adapter is back. But in case it fails while the
-                // adapter is still available, it will retry every second.
-                relm4::spawn(async move {
-                    relm4::tokio::time::sleep(Duration::from_secs(1)).await;
-                    sender.input(Input::StartDiscovery);
-                });
             }
 
             Input::DeviceInfoReady(info) => {


### PR DESCRIPTION
- Detect when bluetooth adapter is toggled, refresh the UI accordingly.
- Fix discovery stuck in broken infinite loop when adapter is reset (e.g. after system suspend).